### PR TITLE
Add bibtex by URL with public link

### DIFF
--- a/src/core/ui/Modal/StartModal/index.js
+++ b/src/core/ui/Modal/StartModal/index.js
@@ -1,16 +1,26 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import styles from './styles.module.css';
 import PrimarySquareButton from 'core/components/PrimarySquareButton';
 import SecondarySquareButton from 'core/components/SecondarySquareButton';
 import ButtonList from 'core/components/ButtonList';
-import { importExampleBibTex } from 'import-modules/bibtex';
+import { importExampleBibTex, importBibTexFromUrl } from 'import-modules/bibtex';
 import AddSeedsModal from 'core/ui/Modal/AddSeedsModal';
 import { UI } from 'core/state/ui';
 import { Store } from 'core/state/data';
+import { getQueryString } from 'utils';
 
 const StartModal = () => {
   const { setModal } = useContext(UI);
   const { updatePapers } = useContext(Store);
+  useEffect(() => {
+    let bibTexUrl = getQueryString('bib');
+    if (bibTexUrl && bibTexUrl.endsWith('.bib')) {
+      importBibTexFromUrl(bibTexUrl).then(papers => {
+        updatePapers(papers, true);
+        setModal(null);
+      });
+    }
+  }, []);
   return (
     <React.Fragment>
       <h1> Welcome to Gecko </h1>

--- a/src/import-modules/bibtex/index.js
+++ b/src/import-modules/bibtex/index.js
@@ -38,6 +38,10 @@ export function importBibTex(evt) {
 // Importing Example BibTex
 export function importExampleBibTex() {
   const url = `${window.location.href}examples/exampleBibTex.bib`;
+  return importBibTexFromUrl(url);
+}
+
+export function importBibTexFromUrl(url) {
   return fetch(url)
     .then(resp => resp.text())
     .then(data => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,3 +5,10 @@ export function groupBy(arr, field) {
     return grouped;
   }, {});
 }
+
+export function getQueryString(field, url) {
+  var href = url ? url : window.location.href;
+  var reg = new RegExp('[?&]' + field + '=([^&#]*)', 'i');
+  var string = reg.exec(href);
+  return string ? string[1] : null;
+}


### PR DESCRIPTION
Fixing https://github.com/CitationGecko/gecko-react/issues/25

Allows for the use of public links like this:
- http://citationgecko.com?bib=https://raw.githubusercontent.com/CitationGecko/gecko-react/master/public/examples/exampleBibTex.bib
- http://localhost:8000/?bib=https://raw.githubusercontent.com/CitationGecko/gecko-react/master/public/examples/exampleBibTex.bib